### PR TITLE
Make travis correctly build server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
+dist: trusty
 language: node_js
 node_js:
-  - "6"
-  - "4"
+  - '6'
+before_install: npm install -g grunt-cli
+script:
+  - make
+matrix:
+  allow_failures:
+  - node_js: '6'


### PR DESCRIPTION
It's still failing, since it need to have `core`
component folder present. But at least it build basic
parts of project.