### PR TITLE
Use `uname -m` for determine linux x64\x686

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ else
         PLATFORM := linux
         SHARED_EXT := .so*
     endif
-    UNAME_P := $(shell uname -p)
-    ifeq ($(UNAME_P),x86_64)
+    UNAME_M := $(shell uname -m)
+    ifeq ($(UNAME_M),x86_64)
         ARCHITECTURE := 64
     endif
-    ifneq ($(filter %86,$(UNAME_P)),)
+    ifneq ($(filter %86,$(UNAME_M)),)
         ARCHITECTURE := 32
     endif
 endif


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Uname), [StackOverlow](https://stackoverflow.com/a/32662963/820501)
and my personal experience to build `server` on `debian` Docker image
`uname -p` return `unknown`, so build process failing.
Using `uname -m` and it works fine