### PR TITLE
br/nodehun reference update

### DIFF
--- a/SpellChecker/package.json
+++ b/SpellChecker/package.json
@@ -7,7 +7,7 @@
     "co": "^4.6.0",
     "config": "^1.21.0",
     "express": "^4.14.0",
-    "nodehun": "git+https://git@github.com/ONLYOFFICE/nodehun.git",
+    "nodehun": "2.0.12",
     "sockjs": "^0.3.17"
   }
 }


### PR DESCRIPTION
the spellechecker's  nodehun dependency fails to update correctly with newer versions of nodejs, seems like either the pull from github isn't working or it's stale- when I grabbed the latest from node (as in the changes in this package.json) everything went smoothly. 

edit: it's a fix for this one: https://github.com/ONLYOFFICE/DocumentServer/issues/304