### PR TITLE
Convert to pdfa

### DIFF
--- a/Common/sources/formatchecker.js
+++ b/Common/sources/formatchecker.js
@@ -271,6 +271,8 @@ exports.getFormatFromString = function(ext) {
 
     case 'pdf':
       return constants.AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_PDF;
+    case 'pdfa':
+      return constants.AVS_OFFICESTUDIO_FILE_OTHER_PDFA;
     case 'swf':
       return constants.AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_SWF;
     case 'djvu':

--- a/Common/sources/utils.js
+++ b/Common/sources/utils.js
@@ -430,16 +430,17 @@ function fillResponse(req, res, uri, error, isJSON) {
     output = {fileUrl: uri, percent: (uri ? 100 : 0), endConvert: !!uri};
   }
   var accept = req.get('Accept');
-  if (accept) {
-    switch (mime.getExtension(accept)) {
-      case "json":
+
+  isJSON = false;
+  if( accept !== null && accept !== undefined ){
+    const acceptArray = accept.split('/');
+    if (acceptArray.length > 1) {
+      if (acceptArray[1] == 'json') {
         isJSON = true;
-        break;
-      case "xml":
-        isJSON = false;
-        break;
+      }
     }
   }
+
   _fillResponse(res, output, isJSON);
 }
 


### PR DESCRIPTION
We would like to use onlyoffice to convert to an valid PDF/A.
This PR provide an new converter-target 'pdfa' and fix an error where the function "mime.getExtension()" is missing.