### PR TITLE
Remove usage license restriction anti-feature

### DIFF
--- a/Common/sources/license.js
+++ b/Common/sources/license.js
@@ -55,20 +55,21 @@ exports.readLicense = function*() {
 	const c_LM = constants.LICENSE_MODE;
 	const resMax = {count: 999999, type: c_LR.Success, mode: c_LM.None, connections: 999999999, users: 999999999};
 	const res = {
-		count: 1,
-		type: c_LR.Error,
-		light: false,
+		count: 999999,
+		type: c_LR.Success,
+		light: true,
 		packageType: oPackageType,
 		mode: c_LM.None,
-		branding: false,
-		connections: constants.LICENSE_CONNECTIONS,
-		usersCount: 0,
+		branding: true,
+		connections: 999999999,
+		usersCount: 999999999,
 		usersExpire: constants.LICENSE_EXPIRE_USERS_ONE_DAY,
-		hasLicense: false,
-		plugins: false,
+		hasLicense: true,
+		plugins: true,
 		buildDate: oBuildDate,
-		endDate: null
+		endDate: new Date(8640000000000000)
 	};
+	return res;
 	let checkFile = false;
 	try {
 		const oFile = fs.readFileSync(configL.get('license_file')).toString();


### PR DESCRIPTION
It is rather stupid to limit the potential of software intentionally, especially in AGPLv3 software, so I made these light changes to remove the anti-features that are hopefully maintainable across versions of the software. I am not sure what each of the license parameters mean, so you're welcome to comment if you hit any more anti-feature so I can adjust the code. Ideally the project owners can document each of the license parameters so we can make a proper patch to render the licensing system inoperative.