### PR TITLE
Do not use JWT when using S3 storage

### DIFF
--- a/FileConverter/sources/converter.js
+++ b/FileConverter/sources/converter.js
@@ -257,7 +257,7 @@ function* downloadFile(docId, uri, fileFrom, withAuthorization) {
     while (constants.NO_ERROR !== res && downloadAttemptCount++ < cfgDownloadAttemptMaxCount) {
       try {
         let authorization;
-        if (cfgTokenEnableRequestOutbox && withAuthorization) {
+        if (cfgTokenEnableRequestOutbox && withAuthorization && config.get('storage.name') !== 'storage-s3') {
           authorization = utils.fillJwtForRequest({url: uri});
         }
         data = yield utils.downloadUrlPromise(uri, cfgDownloadTimeout, cfgDownloadMaxBytes, authorization);


### PR DESCRIPTION
When we are using a S3 storage as document storage service, we can't used JWT token with it.
If you still want to used JWT token with document editing service, you don't want to disable the `services.CoAuthoring.token.enable.request.outbox` option. 
