### PR TITLE
Fix a typo with the default User-Agent header

### DIFF
--- a/Common/config/default.json
+++ b/Common/config/default.json
@@ -87,7 +87,7 @@
 			},
 			"requestDefaults": {
 				"headers": {
-					"userAgent": "Node.js/6.13"
+					"User-Agent": "Node.js/6.13"
 				},
 				"rejectUnauthorized": true
 			},


### PR DESCRIPTION
The [RFC2616](https://tools.ietf.org/html/rfc2616#page-145) sais that the user agent header should be formated like this `User-Agent` not like this `userAgent`.

