### PR TITLE
Fix content-disposition header with filename containing special char

### DIFF
--- a/Common/sources/storage-s3.js
+++ b/Common/sources/storage-s3.js
@@ -205,7 +205,7 @@ exports.getSignedUrl = function(baseUrl, strPath, urlType, optFilename, opt_type
   return new Promise(function(resolve, reject) {
     var expires = (commonDefines.c_oAscUrlTypes.Session === urlType ? cfgExpSessionAbsolute : cfgStorageUrlExpires) || 31536000;
     var userFriendlyName = optFilename ? optFilename.replace(/\//g, "%2f") : path.basename(strPath);
-    var contentDisposition = utils.getContentDispositionS3(userFriendlyName, null, opt_type);
+    var contentDisposition = utils.getContentDisposition(userFriendlyName, null, opt_type);
     if (cfgUseRequestToGetUrl) {
       //default Expires 900 seconds
       var params = {

--- a/Common/sources/utils.js
+++ b/Common/sources/utils.js
@@ -233,24 +233,7 @@ function getContentDisposition (opt_filename, opt_useragent, opt_type) {
   }
   return contentDisposition;
 }
-function getContentDispositionS3 (opt_filename, opt_useragent, opt_type) {
-  var contentDisposition = opt_type ? opt_type : constants.CONTENT_DISPOSITION_ATTACHMENT;
-  if (opt_filename) {
-    contentDisposition += ';';
-    if (opt_useragent != null && -1 != opt_useragent.toLowerCase().indexOf('android')) {
-      contentDisposition += ' filename=' + makeAndroidSafeFileName(opt_filename);
-    } else {
-      if (containsAllAsciiNP(opt_filename)) {
-        contentDisposition += ' filename=' + opt_filename;
-      } else {
-        contentDisposition += ' filename*=UTF-8\'\'' + encodeRFC5987ValueChars(opt_filename);
-      }
-    }
-  }
-  return contentDisposition;
-}
 exports.getContentDisposition = getContentDisposition;
-exports.getContentDispositionS3 = getContentDispositionS3;
 function raiseError(ro, code, msg) {
   ro.abort();
   let error = new Error(msg);


### PR DESCRIPTION
When having a filename that contains a space character, when downloading from a S3 server, the file will not have a correct name in Firefox.

For example, a file "test - test.docx" when downloading in PDF from Firefox will be transformed to "test".

It should be "test - test.pdf" instead.