### PR TITLE
Fix user id concatenation for numerical user ids

### DIFF
--- a/DocService/sources/DocsCoServer.js
+++ b/DocService/sources/DocsCoServer.js
@@ -1863,7 +1863,7 @@ exports.install = function(server, callbackFunction) {
         return;
       }
 
-      const curUserId = user.id + curIndexUser;
+      const curUserId = String(user.id) + curIndexUser;
       conn.docId = data.docid;
       conn.permissions = data.permissions;
       conn.user = {


### PR DESCRIPTION
When we use numeric user ids both variables are of type numeric, thus not concatenating but instead adding them together.

This leads to an error that looks like this:
```
TypeError: undefined is not a function
onlyoffice-document-server     |     at Object.exports.getIndexFromUserId (/snapshot/server/build/server/Common/sources/utils.js:0:0)
```
In the function getIndexFromUserId, it tries to do `substring` on a now numerical variable expecting it to be `string`

This may be related (and will most likely fix)
- https://github.com/ONLYOFFICE/DocumentServer/issues/867
- https://github.com/ONLYOFFICE/DocumentServer/issues/863
