### PR TITLE
Fixed sql requests which have used 'LIMIT' clause in oracle database

### DIFF
--- a/DocService/sources/changes2forgotten.js
+++ b/DocService/sources/changes2forgotten.js
@@ -58,18 +58,6 @@ var LOOP_TIMEOUT = 1000;
 var EXEC_TIMEOUT = WAIT_TIMEOUT + utils.getConvertionTimeout(undefined);
 
 let addSqlParam = sqlBase.baseConnector.addSqlParameter;
-function getDocumentsWithChanges(ctx) {
-  return new Promise(function(resolve, reject) {
-    let sqlCommand = `SELECT * FROM ${cfgTableResult} WHERE EXISTS(SELECT id FROM ${cfgTableChanges} WHERE tenant=${cfgTableResult}.tenant AND id = ${cfgTableResult}.id LIMIT 1);`;
-    sqlBase.baseConnector.sqlQuery(ctx, sqlCommand, function(error, result) {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(result);
-      }
-    }, undefined, undefined);
-  });
-}
 function updateDoc(ctx, docId, status, callback) {
   return new Promise(function(resolve, reject) {
     let values = [];
@@ -109,7 +97,7 @@ function shutdown() {
       ctx.logger.debug('shutdown start wait pubsub deliver');
       yield utils.sleep(LOOP_TIMEOUT);
 
-      let documentsWithChanges = yield getDocumentsWithChanges(ctx);
+      let documentsWithChanges = yield sqlBase.getDocumentsWithChanges(ctx);
       ctx.logger.debug('shutdown docs with changes count = %s', documentsWithChanges.length);
       let docsWithEmptyForgotten = [];
       let docsWithOutOfDateForgotten = [];

--- a/DocService/sources/taskresult.js
+++ b/DocService/sources/taskresult.js
@@ -314,24 +314,6 @@ function removeIf(ctx, mask) {
     }, undefined, undefined, values);
   });
 }
-function getExpired(ctx, maxCount, expireSeconds) {
-  return new Promise(function(resolve, reject) {
-    let values = [];
-    let expireDate = new Date();
-    utils.addSeconds(expireDate, -expireSeconds);
-    let sqlParam1 = addSqlParam(expireDate, values);
-    let sqlParam2 = addSqlParam(maxCount, values);
-    let sqlCommand = `SELECT * FROM ${cfgTableResult} WHERE last_open_date <= ${sqlParam1}` +
-      ` AND NOT EXISTS(SELECT tenant, id FROM ${cfgTableChanges} WHERE ${cfgTableChanges}.tenant = ${cfgTableResult}.tenant AND ${cfgTableChanges}.id = ${cfgTableResult}.id LIMIT 1) LIMIT ${sqlParam2};`;
-    sqlBase.baseConnector.sqlQuery(ctx, sqlCommand, function(error, result) {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(result);
-      }
-    }, undefined, undefined, values);
-  });
-}
 
 exports.TaskResultData = TaskResultData;
 exports.upsert = upsert;
@@ -342,4 +324,4 @@ exports.restoreInitialPassword = restoreInitialPassword;
 exports.addRandomKeyTask = addRandomKeyTask;
 exports.remove = remove;
 exports.removeIf = removeIf;
-exports.getExpired = getExpired;
+exports.getExpired = sqlBase.getExpired;


### PR DESCRIPTION
Added oracle-sepific syntax for sql querys with word LIMIT.
Sql queries have moved from _changes2forgotten.js_ and _taskresult.js_ to _baseConnector.js_ and now called from here. 
