### PR TITLE
[oracle] Fixed NULL comparations and type NCLOB changed to NVARCHAR2

### DIFF
--- a/DocService/sources/baseConnector.js
+++ b/DocService/sources/baseConnector.js
@@ -338,7 +338,7 @@ exports.healthCheck = function (ctx) {
   });
 };
 
-exports.getEmptyCallbacks = function(ctx) {
+exports.getEmptyCallbacks = baseConnector.getEmptyCallbacks ?? function(ctx) {
   return new Promise(function(resolve, reject) {
     const sqlCommand = `SELECT DISTINCT t1.tenant, t1.id FROM ${cfgTableChanges} t1 LEFT JOIN ${cfgTableResult} t2 ON t2.tenant = t1.tenant AND t2.id = t1.id WHERE t2.callback = '';`;
     baseConnector.sqlQuery(ctx, sqlCommand, function(error, result) {

--- a/DocService/sources/oracleBaseConnector.js
+++ b/DocService/sources/oracleBaseConnector.js
@@ -158,8 +158,8 @@ function getTableColumns(ctx, tableName) {
 }
 
 function getEmptyCallbacks(ctx) {
-  const joinCondition = 'ON t2.tenant = t1.tenant AND t2.id = t1.id WHERE t2.callback IS NULL';
-  const sqlCommand = `SELECT DISTINCT t1.tenant, t1.id FROM ${cfgTableChanges} t1 LEFT JOIN ${cfgTableResult} t2 ${joinCondition}`;
+  const joinCondition = 'ON t2.tenant = t1.tenant AND t2.id = t1.id AND t2.callback IS NULL';
+  const sqlCommand = `SELECT DISTINCT t1.tenant, t1.id FROM ${cfgTableChanges} t1 INNER JOIN ${cfgTableResult} t2 ${joinCondition}`;
   return executeQuery(ctx, sqlCommand);
 }
 

--- a/DocService/sources/oracleBaseConnector.js
+++ b/DocService/sources/oracleBaseConnector.js
@@ -157,6 +157,12 @@ function getTableColumns(ctx, tableName) {
   return executeQuery(ctx, `SELECT LOWER(column_name) AS column_name FROM user_tab_columns WHERE table_name = '${tableName.toUpperCase()}'`);
 }
 
+function getEmptyCallbacks(ctx) {
+  const joinCondition = 'ON t2.tenant = t1.tenant AND t2.id = t1.id WHERE t2.callback IS NULL';
+  const sqlCommand = `SELECT DISTINCT t1.tenant, t1.id FROM ${cfgTableChanges} t1 LEFT JOIN ${cfgTableResult} t2 ${joinCondition}`;
+  return executeQuery(ctx, sqlCommand);
+}
+
 function getDocumentsWithChanges(ctx) {
   const existingId = `SELECT id FROM ${cfgTableChanges} WHERE tenant=${cfgTableResult}.tenant AND id = ${cfgTableResult}.id AND ROWNUM <= 1`;
   const sqlCommand = `SELECT * FROM ${cfgTableResult} WHERE EXISTS(${existingId})`;
@@ -329,6 +335,7 @@ module.exports = {
   addSqlParameter,
   concatParams,
   getTableColumns,
+  getEmptyCallbacks,
   getDocumentsWithChanges,
   getExpired,
   upsert,

--- a/schema/oracle/createdb.sql
+++ b/schema/oracle/createdb.sql
@@ -33,10 +33,10 @@ CREATE TABLE onlyoffice.task_result (
     last_open_date TIMESTAMP NOT NULL,
     user_index NUMBER DEFAULT 1 NOT NULL,
     change_id NUMBER DEFAULT 0 NOT NULL,
-    callback NVARCHAR2(2000),  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
-    baseurl NVARCHAR2(2000),  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
-    password NVARCHAR2(2000) NULL,
-    additional NVARCHAR2(2000) NULL,
+    callback NCLOB,  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
+    baseurl NCLOB,  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
+    password NCLOB NULL,
+    additional NCLOB NULL,
     CONSTRAINT task_result_unique UNIQUE (tenant, id),
     CONSTRAINT task_result_unsigned_int CHECK (user_index BETWEEN 0 AND 4294967295 AND change_id BETWEEN 0 AND 4294967295)
 );

--- a/schema/oracle/createdb.sql
+++ b/schema/oracle/createdb.sql
@@ -33,10 +33,10 @@ CREATE TABLE onlyoffice.task_result (
     last_open_date TIMESTAMP NOT NULL,
     user_index NUMBER DEFAULT 1 NOT NULL,
     change_id NUMBER DEFAULT 0 NOT NULL,
-    callback NCLOB,  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
-    baseurl NCLOB,  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
-    password NCLOB NULL,
-    additional NCLOB NULL,
+    callback NVARCHAR2(2000),  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
+    baseurl NVARCHAR2(2000),  -- codebase uses '' as default values here, but Oracle treat '' as NULL, so NULL permitted for this value.
+    password NVARCHAR2(2000) NULL,
+    additional NVARCHAR2(2000) NULL,
     CONSTRAINT task_result_unique UNIQUE (tenant, id),
     CONSTRAINT task_result_unsigned_int CHECK (user_index BETWEEN 0 AND 4294967295 AND change_id BETWEEN 0 AND 4294967295)
 );


### PR DESCRIPTION
In oracle DB NULL is a sepical object which have no comparation ability, so any comaration operators will not work as expected. 
Also, oracle treat empty strings as NULL, so getEmptyCallbacks() method which uses comparation  _t2.callback = ''_ will fail. 

Another problem is _callback, baseurl, password, additional_ fields of _task_result_ table and _change_data_ of _doc_changes_ table
which have longtext/text data type in MySql, so replacement for these in oracle will be NCLOB type, but unfortunately NCLOB type cannot be used in comparations due to it defenition. So all these fields could leads to error if comparation will occure. Function TO_NCHAR() casts type of NCLOB to NVARCHAR2, but with data lost. My proposal is changing fields type to NVARCHAR2, but we need to know real limits, because _change_data_ must be NCLOB.

UPD: desied to not change DB types to NVARCHAR2